### PR TITLE
Add an exception when parsing of response fails

### DIFF
--- a/sheepdog_exporter/sheepdog_exporter.py
+++ b/sheepdog_exporter/sheepdog_exporter.py
@@ -218,7 +218,12 @@ class Exporter:
         '''
         url = '{}/{}/{}/export/?node_label={}&format=json'.format(self.sheep_url, program, project, my_type)
         response = requests.get(url, headers=self.headers())
-        return response.json()['data']
+        try:
+            submissions = response.json()['data']
+        except Exception as e:
+            print('WARNING!!! There was a problem parsing the submission for {}, {}'.format(my_type, str(e)))
+            submissions = {}
+        return submissions
     
     def get_json_submission_by_type(self, program, project, my_type):
         '''

--- a/sheepdog_exporter/sheepdog_exporter.py
+++ b/sheepdog_exporter/sheepdog_exporter.py
@@ -220,8 +220,10 @@ class Exporter:
         response = requests.get(url, headers=self.headers())
         try:
             submissions = response.json()['data']
-        except Exception as e:
-            print('WARNING!!! There was a problem parsing the submission for {}, {}'.format(my_type, str(e)))
+        except KeyError as e:
+            message = '''WARNING!!! There was a problem parsing the 
+                         submission for {}, missing key: {}'''.format(my_type, str(e))
+            print(message, file=sys.stderr)
             submissions = {}
         return submissions
     

--- a/sheepdog_exporter/sheepdog_exporter.py
+++ b/sheepdog_exporter/sheepdog_exporter.py
@@ -220,7 +220,7 @@ class Exporter:
         response = requests.get(url, headers=self.headers())
         try:
             submissions = response.json()['data']
-        except KeyError as e:
+        except (KeyError, ValueError, UnicodeDecodeError) as e:
             message = '''WARNING!!! There was a problem parsing the 
                          submission for {}, missing key: {}'''.format(my_type, str(e))
             print(message, file=sys.stderr)


### PR DESCRIPTION
Helps to address the parsing error in #7 . Will print a loud warning to the CLI when a metadata item does not return the expected JSON.

Better exception handling and testing is warranted in future work